### PR TITLE
Make TwoWire methods virtual

### DIFF
--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -49,33 +49,34 @@ class TwoWire : public Stream
     static void onReceiveService(uint8_t*, int);
   public:
     TwoWire();
-    void begin();
-    void begin(uint8_t);
-    void begin(int);
-    void end();
-    void setClock(uint32_t);
-    void beginTransmission(uint8_t);
-    void beginTransmission(int);
-    uint8_t endTransmission(void);
-    uint8_t endTransmission(uint8_t);
-    uint8_t requestFrom(uint8_t, uint8_t);
-    uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
-	uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
-    uint8_t requestFrom(int, int);
-    uint8_t requestFrom(int, int, int);
+    virtual ~TwoWire();
+    virtual begin();
+    virtual begin(uint8_t);
+    virtual begin(int);
+    virtual end();
+    virtual setClock(uint32_t);
+    virtual beginTransmission(uint8_t);
+    virtual void beginTransmission(int);
+    virtual uint8_t endTransmission(void);
+    virtual uint8_t endTransmission(uint8_t);
+    virtual uint8_t requestFrom(uint8_t, uint8_t);
+    virtual uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
+    virtual uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
+    virtual uint8_t requestFrom(int, int);
+    virtual uint8_t requestFrom(int, int, int);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *, size_t);
     virtual int available(void);
     virtual int read(void);
     virtual int peek(void);
     virtual void flush(void);
-    void onReceive( void (*)(int) );
-    void onRequest( void (*)(void) );
+    virtual void onReceive( void (*)(int) );
+    virtua void onRequest( void (*)(void) );
 
-    inline size_t write(unsigned long n) { return write((uint8_t)n); }
-    inline size_t write(long n) { return write((uint8_t)n); }
-    inline size_t write(unsigned int n) { return write((uint8_t)n); }
-    inline size_t write(int n) { return write((uint8_t)n); }
+    virtual inline size_t write(unsigned long n) { return write((uint8_t)n); }
+    virtual inline size_t write(long n) { return write((uint8_t)n); }
+    virtual inline size_t write(unsigned int n) { return write((uint8_t)n); }
+    virtual inline size_t write(int n) { return write((uint8_t)n); }
     using Print::write;
 };
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -49,7 +49,6 @@ class TwoWire : public Stream
     static void onReceiveService(uint8_t*, int);
   public:
     TwoWire();
-    virtual ~TwoWire();
     virtual begin();
     virtual begin(uint8_t);
     virtual begin(int);


### PR DESCRIPTION
This allows them to be overridden by downstream projects that need to subclass TwoWire

For example: https://github.com/Testato/SoftwareWire